### PR TITLE
WIP Django 1.8 support

### DIFF
--- a/barbeque/tests/views/test_mixins.py
+++ b/barbeque/tests/views/test_mixins.py
@@ -50,7 +50,7 @@ class TestLoginRequiredMixin:
         assert response.status_code == 302
         assert response['Location'] == '/login/?next=/protected/'
 
-        assert info_func.assert_called_once()
+        assert info_func.call_count == 1
 
     def test_logged_in(self, rf, settings):
         settings.LOGIN_URL = '/login/'

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-addopts = -vs --clearcache --tb=short --pep8 --flakes -p no:doctest
+addopts = -vs --cache-clear --tb=short --pep8 --flakes -p no:doctest
 
 norecursedirs = .tox
 python_files =

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ tests_require = [
     'psutil',
     'pytest',
     'pytest-cov',
+    'pytest-cache>=1.0',
     'pytest-pep8',
     'pytest-flakes',
     'pytest-django',

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ def read(*parts):
 
 
 tests_require = [
-    'coverage',
+    'coverage>=4.0',
     'mock',
     'openpyxl',
     'psutil',

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ skipsdist = True
 commands =
 	pip install -e {toxinidir}
 	pip install -e {toxinidir}[tests]
-	py.test -vs --junitxml=junit-{envname}.xml --clearcache --cov {toxinidir}/barbeque --cov-config {toxinidir}/../.coveragerc --cov-report xml
+	py.test -vs --junitxml=junit-{envname}.xml --cache-clear --cov {toxinidir}/barbeque --cov-config {toxinidir}/.coveragerc --cov-report xml
 
 dependencies15 =
 	https://github.com/django/django/archive/stable/1.5.x.zip#egg=django
@@ -11,6 +11,8 @@ dependencies16 =
 	https://github.com/django/django/archive/stable/1.6.x.zip#egg=django
 dependencies17 =
 	https://github.com/django/django/archive/stable/1.7.x.zip#egg=django
+dependencies18 =
+	https://github.com/django/django/archive/stable/1.8.x.zip#egg=django
 
 [testenv:2.6-1.5.x]
 basepython = python2.6
@@ -37,6 +39,11 @@ basepython = python2.7
 deps =
 	{[testenv]dependencies17}
 
+[testenv:2.7-1.8.x]
+basepython = python2.7
+deps =
+	{[testenv]dependencies18}
+
 [testenv:3.4-1.6.x]
 basepython = python3.4
 deps =
@@ -47,6 +54,11 @@ basepython = python3.4
 deps =
 	{[testenv]dependencies17}
 
+[testenv:3.4-1.8.x]
+basepython = python3.4
+deps =
+	{[testenv]dependencies18}
+
 [testenv:pypy-1.6.x]
 basepython = pypy
 deps =
@@ -56,6 +68,11 @@ deps =
 basepython = pypy
 deps =
     {[testenv]dependencies17}
+
+[testenv:pypy-1.8.x]
+basepython = pypy
+deps =
+    {[testenv]dependencies18}
 
 [docs]
 commands =


### PR DESCRIPTION
* Adds django 1.8 to tox config
* Updates test dependency to coverage >= 4.0
* Updates to latest pytest-cache dependency

I'll mark this as work in progress as I'm just about to use it in a django 1.8 project so I'm not sure if the tests cover everything.